### PR TITLE
fix: filter interactions by item_id instead of learner_id

### DIFF
--- a/src/app/routers/interactions.py
+++ b/src/app/routers/interactions.py
@@ -19,6 +19,6 @@ async def get_interactions(
     interactions = await read_interactions(session)
     if item_id is not None:
         interactions = [
-            i for i in interactions if i.learner_id == item_id
+            i for i in interactions if i.item_id == item_id
         ]  # BUG: should filter by i.item_id
     return interactions


### PR DESCRIPTION
fix: filter interactions by item_id instead of learner_id
